### PR TITLE
Add Running FOMO to Recent Projects

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -537,7 +537,7 @@
                     </div>
                     <div class="card">
                         <h3><a href="https://runningfomo.com/" target="_blank" rel="noopener noreferrer">Running FOMO</a></h3>
-                        <p>I'm responsible for this website: an events calendar aggregating Berlin's running scene — group runs, races, and meetups. Originally backed by a Google Sheet, it now runs on PostgreSQL with a stateless cron worker that scrapes Strava, Heylo, Meetup and more, pushing everything back through a single Next.js source of truth.</p>
+                        <p>I'm responsible for this website: Berlin's go-to platform to discover running events and run clubs — group runs, races, and community meetups — plus our own branded Running FOMO events. Originally backed by a Google Sheet, it now runs on PostgreSQL with a stateless cron worker that scrapes Strava, Heylo, Meetup and more, pushing everything back through a single Next.js source of truth.</p>
                     </div>
                 </div>
             </div>

--- a/src/index.html
+++ b/src/index.html
@@ -535,6 +535,10 @@
                         <h3><a href="https://github.com/mxschmitt/pg-backup-scheduler" target="_blank" rel="noopener noreferrer">pg-backup-scheduler</a></h3>
                         <p>Self-hosted PostgreSQL backup scheduler with Docker-based version matching. Perfect for Supabase users avoiding premium backup costs. Built with Go - single binary, no dependencies beyond Docker.</p>
                     </div>
+                    <div class="card">
+                        <h3><a href="https://runningfomo.com/" target="_blank" rel="noopener noreferrer">Running FOMO</a></h3>
+                        <p>I'm responsible for this website: an events calendar aggregating Berlin's running scene — group runs, races, and meetups. Originally backed by a Google Sheet, it now runs on PostgreSQL with a stateless cron worker that scrapes Strava, Heylo, Meetup and more, pushing everything back through a single Next.js source of truth.</p>
+                    </div>
                 </div>
             </div>
 

--- a/src/index.html
+++ b/src/index.html
@@ -537,7 +537,7 @@
                     </div>
                     <div class="card">
                         <h3><a href="https://runningfomo.com/" target="_blank" rel="noopener noreferrer">Running FOMO</a></h3>
-                        <p>I'm responsible for this website: Berlin's go-to platform to discover running events and run clubs — group runs, races, and community meetups — plus our own branded Running FOMO events. Originally backed by a Google Sheet, it now runs on PostgreSQL with a stateless cron worker that scrapes Strava, Heylo, Meetup and more, pushing everything back through a single Next.js source of truth.</p>
+                        <p>I'm responsible for this website: Berlin's go-to platform to discover running events and run clubs, plus our own branded Running FOMO events. Migrated from a Google Sheet to PostgreSQL, with a stateless cron worker scraping Strava, Heylo, Meetup and more.</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Adds a Running FOMO card to the Recent Projects section.

## What

- Links to https://runningfomo.com/ and notes I'm responsible for the site
- Describes it as a Berlin running events calendar (group runs, races, meetups)
- Highlights the spicy technical bits: migrated from a Google Sheet backend to PostgreSQL, with a stateless cron worker scraping Strava, Heylo, Meetup and more, pushing everything back through a single Next.js source of truth

Kept the copy to ~3 sentences to match the length of the existing project cards.